### PR TITLE
feat(routes/dashboard) - Use last event as begining of timeline

### DIFF
--- a/app/components/ax-select.js
+++ b/app/components/ax-select.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+    content: null,
+
+    selectedValue: Ember.computed.alias('value'),
+    displayValue: '',
+    targetProperty: '',
+    didInitAttrs() {
+        this._super(...arguments);
+        var content = this.get('content');
+
+        if (!content) {
+            this.set('content', []);
+        }
+    },
+    selectedValueObserver: Ember.observer('selectedValue', function () {
+      const valuePath = this.get('valuePath');
+      var selectedObject;
+
+      this.get('content').forEach(obj => {
+        if (obj[valuePath] === this.get('selectedValue')) {
+          selectedObject = obj;
+        }
+      });
+
+      if (!selectedObject) {
+        return;
+      }
+
+      var targetEl = this.$('.' + this.get('name') + ' option[value="' + selectedObject[valuePath] + '"]');
+
+      if (targetEl) {
+        targetEl.attr('selected','selected');
+      }
+    }),
+    actions: {
+        change() {
+            const selectedEl = this.$('select')[0];
+            const selectedIndex = selectedEl.selectedIndex;
+            const valuePath = this.get('valuePath');
+            const content = this.get('content');
+            const selectedValue = content[selectedIndex][valuePath];
+
+            this.set('selectedValue', content[selectedIndex]);
+            this.set('value', content[selectedIndex]);
+            // send action to target
+            this.get('target').send(this.get('action'), selectedValue);
+        }
+    }
+});

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -1,4 +1,4 @@
-/*globals appInsights*/
+/*globals appInsights, moment*/
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
@@ -12,11 +12,7 @@ export default Ember.Controller.extend({
     });
   },
   commitsLoading: true,
-  selectMenuDays: 0,
   daysBack: 0,
-  daysBackObserver: Ember.observer('selectMenuDays', function () {
-    this.send('changeTimeView', this.get('selectMenuDays'));
-  }),
   /**
   Tracks actions across various cards
   **/
@@ -31,6 +27,15 @@ export default Ember.Controller.extend({
       appInsights.trackEvent('conversationClick');
     });
   },
+  _intialDaysBackObserve: true,
+  daysBackObserver: Ember.observer('selectMenuDays', function () {
+
+    if (this.get('_intialDaysBackObserve')) {
+      this.set('_intialDaysBackObserve', true);
+      return;
+    }
+    this.send('changeTimeView', this.get('selectMenuDays'));
+  }),
   pushEvents: function () {
     var events = this.get('events'),
         pushEvents = [];
@@ -74,42 +79,46 @@ export default Ember.Controller.extend({
 
     return pushEvents;
   }.property('events'),
-  ranges: [
-    { name: 'Today',
-      daysBack: 1,
-      active: true
-    },
-    {
-      name: 'Since Yesterday',
-      daysBack: 2,
-      active: false
-    },
-    {
-      name: 'Since 2 Days Ago',
-      daysBack: 3,
-      active: false
-    },
-    {
-      name: 'Since 3 Days Ago',
-      daysBack: 4,
-      active: false
-    },
-    {
-      name: 'Since 4 Days Ago',
-      daysBack: 5,
-      active: false
-    },
-    {
-      name: 'Since 5 Days Ago',
-      daysBack: 6,
-      active: false
-    },
-    {
-      name: 'Since 20 Days Ago',
-      daysBack: 20,
-      active: false
-    }
-  ],
+  latestEventDate: null,
+  ranges: function () {
+    var latestEventDate = this.get('latestEventDate') || new Date(Date.now());
+    return [
+      { name: 'Since ' + moment(latestEventDate).fromNow(),
+        daysBack: 1,
+        active: true
+      },
+      {
+        name: 'Since ' + moment(latestEventDate).subtract(1, 'days').fromNow(),
+        daysBack: 2,
+        active: false
+      },
+      {
+        name: 'Since ' + moment(latestEventDate).subtract(3, 'days').fromNow(),
+        daysBack: 3,
+        active: false
+      },
+      {
+        name: 'Since ' + moment(latestEventDate).subtract(4, 'days').fromNow(),
+        daysBack: 4,
+        active: false
+      },
+      {
+        name: 'Since ' + moment(latestEventDate).subtract(5, 'days').fromNow(),
+        daysBack: 5,
+        active: false
+      },
+      {
+        name: 'Since ' + moment(latestEventDate).subtract(6, 'days').fromNow(),
+        daysBack: 6,
+        active: false
+      },
+      {
+        name: 'Since ' + moment(latestEventDate).subtract(20, 'days').fromNow(),
+        daysBack: 20,
+        active: false
+      }
+    ];
+  }.property('latestEventDate'),
   rangeData: function () {
     return this.get('ranges');
   }.property('ranges.@each.active')

--- a/app/helpers/lookup.js
+++ b/app/helpers/lookup.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function lookup(params) {
+  return params[0][params[1]];
+}
+
+export default Ember.Helper.helper(lookup);

--- a/app/models/gollum-event.js
+++ b/app/models/gollum-event.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  
+});

--- a/app/serializers/event.js
+++ b/app/serializers/event.js
@@ -113,12 +113,9 @@ export default DS.RESTSerializer.extend({
           linkageObjects = linkageObjects.concat(linkage);
           break;
         case 'publicEvent':
-          // todo: implement
-          break;
         case 'commitCommentEvent':
-          // todo: implement
-          break;
         case 'watchEvent':
+        case 'gollumEvent':
           break;
       }
 

--- a/app/templates/components/ax-profile-card.hbs
+++ b/app/templates/components/ax-profile-card.hbs
@@ -4,7 +4,9 @@
   </div>
   <div class="card-content white-text profile-content">
     <h5>{{user.name}}</h5>
-    <i class="mdi-communication-location-on"></i>{{user.location}}
+    {{#if user.location}}
+      <i class="mdi-communication-location-on"></i>{{user.location}}
+    {{/if}}
     <p><a href="{{user.blog}}" target="_blank" class="truncate">{{user.blog}}</a></p>
     <p>{{user.company}}</p>
   </div>

--- a/app/templates/components/ax-select.hbs
+++ b/app/templates/components/ax-select.hbs
@@ -1,0 +1,10 @@
+<select class="browser-default {{name}}" disabled={{disabled}} {{action 'change' on='change'}}>
+    {{#each content key="@index" as |item|}}
+        <option value="{{lookup item valuePath}}" selected={{is-equal item selectedValue}}>
+            {{item.name}}
+        </option>
+    {{/each}}
+    {{#if label}}
+        <label>{{label}}</label>
+    {{/if}}
+</select>

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -5,7 +5,7 @@
       {{ax-navbar user=user}}
       {{#if optIn}}
         <div class="row col s12 m10 range-selector-small">
-          {{md-select action="changeTimeView" content=ranges optionLabelPath="content.name" optionValuePath="content.daysBack" value=selectMenuDays }}
+          {{ax-select content=ranges valuePath="daysBack" displayPath="name" name="range-selector-small" action="changeTimeView" target=this value=selectMenuDays }}
         </div>
         <div class="row">
           <div class="col s12 m4">

--- a/tests/integration/components/ax-select-test.js
+++ b/tests/integration/components/ax-select-test.js
@@ -1,0 +1,27 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+
+moduleForComponent('ax-select', 'Integration | Component | ax select', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{ax-select}}`);
+
+  assert.equal(this.$().text(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#ax-select}}
+      template block text
+    {{/ax-select}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/unit/helpers/lookup-test.js
+++ b/tests/unit/helpers/lookup-test.js
@@ -1,0 +1,10 @@
+import { lookup } from '../../../helpers/lookup';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | lookup');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  var result = lookup(42);
+  assert.ok(result);
+});

--- a/tests/unit/models/gollum-event-test.js
+++ b/tests/unit/models/gollum-event-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('gollum-event', 'Unit | Model | gollum event', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  var model = this.subject();
+  // var store = this.store();
+  assert.ok(!!model);
+});


### PR DESCRIPTION
The timeline on the right hand side shouldn't always start at present
time and rather should start at the most recent event on the github
event stream.

- Timeline now starts on latest event
- Mobile time selector is now native rather than materialize
- Mobile time selector is in-sync with desktop time selector
- Fixed issue where time loading routine was executed 2x's.